### PR TITLE
feat: improve TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,9 +13,7 @@ type LifecycleAction = (arg: {
   args: Args;
 }) => void;
 
-type NoOp = () => void;
-
-type ActionFunction = BaseState | ((...args: Args) => BaseState) | ((...args: Args) => void) | NoOp;
+type ActionFunction = BaseState | ((...args: Args) => BaseState) | ((...args: Args) => void);
 
 type BaseActions = {
   _enter?: LifecycleAction;
@@ -30,7 +28,7 @@ type ExtractStates<States extends BaseStates> = DetectFallBackState<Exclude<keyo
 type ExtractObjectValues<Object> = Object[keyof Object];
 
 type GetActionFunctionMapping<Actions extends BaseActions> = {
-  [Key in Exclude<keyof Actions, '_enter' | '_exit'>]: Actions[Key] extends string
+  [Key in Exclude<keyof Actions, '_enter' | '_exit'>]: Actions[Key] extends BaseState
     ? () => Actions[Key]
     : Actions[Key];
 };
@@ -46,7 +44,7 @@ type Unsubscribe = () => void;
 type Subscribe<S extends BaseState> = (callback: (state: S) => void) => Unsubscribe;
 
 type StateMachine<State extends BaseState, Actions> = {
-  [Key in keyof Actions]: Actions[Key] | NoOp;
+  [Key in keyof Actions]: Actions[Key];
 } & {
   subscribe: Subscribe<State>;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,50 +1,50 @@
 
-type State = string | symbol
+type BaseState = string | symbol
 
-type Action = string
+type BaseAction = string
 
-type States<S extends State = State> = Record<S, Actions>
+type BaseStates<State extends BaseState = BaseState> = Record<State, BaseActions>
 
 type Args = any[]
 
-type LifecycleAction = (arg: { from: State, to: State, event: Action, args: Args }) => void
+type LifecycleAction = (arg: { from: BaseState, to: BaseState, event: BaseAction, args: Args }) => void
 
-type ActionFunction = State | ((...args: Args) => State) | ((...args: Args) => void)
+type ActionFunction = BaseState | ((...args: Args) => BaseState) | ((...args: Args) => void)
 
-type Actions = {
+type BaseActions = {
 	_enter?: LifecycleAction
 	_exit?: LifecycleAction
-	[key: Action]: ActionFunction
+	[key: BaseAction]: ActionFunction
 }
 
-type DetectFallBackState<X extends string | symbol> = X extends '*' ? string : X
+type DetectFallBackState<State extends BaseState> = State extends '*' ? string : State
 
-type ExtractStates<Sts extends States> = DetectFallBackState<Exclude<keyof Sts, number>>
+type ExtractStates<States extends BaseStates> = DetectFallBackState<Exclude<keyof States, number>>
 
-type ExtractObjectValues<A> = A[keyof A]
+type ExtractObjectValues<Object> = Object[keyof Object]
 
-type GetActionFunctionMapping<A extends Record<Action, ActionFunction>> = {
-	[Key in Exclude<keyof A, '_enter' | '_exit'>]: A[Key] extends string ? () => A[Key] : A[Key]
+type GetActionFunctionMapping<Actions extends BaseActions> = {
+	[Key in Exclude<keyof Actions, '_enter' | '_exit'>]: Actions[Key] extends string ? () => Actions[Key] : Actions[Key]
 }
 
-type GetActionMapping<A extends Record<State, Actions>> = ExtractObjectValues<{
-	[Key in keyof A]: GetActionFunctionMapping<A[Key]>
+type GetActionMapping<States extends BaseStates> = ExtractObjectValues<{
+	[Key in keyof States]: GetActionFunctionMapping<States[Key]>
 }>
 
-type ExtractActions<Sts extends States> = GetActionMapping<Sts>
+type ExtractActions<States extends BaseStates> = GetActionMapping<States>
 
 type Unsubscribe = () => void
 
-type Subscribe<S> = (callback: (state: S) => void) => Unsubscribe
+type Subscribe<S extends BaseState> = (callback: (state: S) => void) => Unsubscribe
 
-type StateMachine<S extends State, A> = {
-	[key in keyof A]: A[key]
+type StateMachine<State extends BaseState, Actions> = {
+	[key in keyof Actions]: Actions[key]
 } & {
-	subscribe: Subscribe<S>
+	subscribe: Subscribe<State>
 }
 
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
 
-declare const svelteFsm: <Sts extends Readonly<States>, S extends ExtractStates<Sts>>(state: S, states: Sts) => StateMachine<ExtractStates<Sts>, UnionToIntersection<ExtractActions<Sts>>>
+declare const svelteFsm: <Sts extends Readonly<BaseStates>, S extends ExtractStates<Sts>>(state: S, states: Sts) => StateMachine<ExtractStates<Sts>, UnionToIntersection<ExtractActions<Sts>>>
 
 export default svelteFsm

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 
-declare type State = string | symbol | number
+declare type State = string | symbol
 
 declare type Action = string
 
@@ -17,7 +17,7 @@ declare type Actions = {
 	[key: Action]: ActionFunction
 }
 
-declare type ExtractStates<Sts extends States> = keyof Sts
+declare type ExtractStates<Sts extends States> = Exclude<keyof Sts, number>
 
 type ExtractObjectValues<A> = A[keyof A]
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,4 +9,12 @@ declare type StateDescription = {
 
 declare type ExtractStates<S extends States> = keyof S
 
-export default function svelteFsm<S extends States>(state: ExtractStates<S>, states: S): any
+declare type Unsubscribe = () => void
+
+declare type Subscribe<State> = (callback: (state: State) => void) => Unsubscribe
+
+export default function svelteFsm<S extends States>(state: ExtractStates<S>, states: S): {
+	[key: string]: () => State
+} & {
+	subscribe: Subscribe<ExtractStates<S>>
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,52 +1,63 @@
+type BaseState = string | symbol;
 
-type BaseState = string | symbol
+type BaseAction = string;
 
-type BaseAction = string
+type BaseStates<State extends BaseState = BaseState> = Record<State, BaseActions>;
 
-type BaseStates<State extends BaseState = BaseState> = Record<State, BaseActions>
+type Args = any[];
 
-type Args = any[]
+type LifecycleAction = (arg: {
+  from: BaseState | null;
+  to: BaseState;
+  event: BaseAction | null;
+  args: Args;
+}) => void;
 
-type LifecycleAction = (arg: { from: BaseState | null, to: BaseState, event: BaseAction | null, args: Args }) => void
+type NoOp = () => void;
 
-type NoOp = () => void
-
-type ActionFunction = BaseState | ((...args: Args) => BaseState) | ((...args: Args) => void) | NoOp
+type ActionFunction = BaseState | ((...args: Args) => BaseState) | ((...args: Args) => void) | NoOp;
 
 type BaseActions = {
-	_enter?: LifecycleAction
-	_exit?: LifecycleAction
-	[key: BaseAction]: ActionFunction
-}
+  _enter?: LifecycleAction;
+  _exit?: LifecycleAction;
+  [key: BaseAction]: ActionFunction;
+};
 
-type DetectFallBackState<State extends BaseState> = State extends '*' ? string : State
+type DetectFallBackState<State extends BaseState> = State extends '*' ? string : State;
 
-type ExtractStates<States extends BaseStates> = DetectFallBackState<Exclude<keyof States, number>>
+type ExtractStates<States extends BaseStates> = DetectFallBackState<Exclude<keyof States, number>>;
 
-type ExtractObjectValues<Object> = Object[keyof Object]
+type ExtractObjectValues<Object> = Object[keyof Object];
 
 type GetActionFunctionMapping<Actions extends BaseActions> = {
-	[Key in Exclude<keyof Actions, '_enter' | '_exit'>]: Actions[Key] extends string ? () => Actions[Key] : Actions[Key]
-}
+  [Key in Exclude<keyof Actions, '_enter' | '_exit'>]: Actions[Key] extends string
+    ? () => Actions[Key]
+    : Actions[Key];
+};
 
 type GetActionMapping<States extends BaseStates> = ExtractObjectValues<{
-	[Key in keyof States]: GetActionFunctionMapping<States[Key]>
-}>
+  [Key in keyof States]: GetActionFunctionMapping<States[Key]>;
+}>;
 
-type ExtractActions<States extends BaseStates> = GetActionMapping<States>
+type ExtractActions<States extends BaseStates> = GetActionMapping<States>;
 
-type Unsubscribe = () => void
+type Unsubscribe = () => void;
 
-type Subscribe<S extends BaseState> = (callback: (state: S) => void) => Unsubscribe
+type Subscribe<S extends BaseState> = (callback: (state: S) => void) => Unsubscribe;
 
 type StateMachine<State extends BaseState, Actions> = {
-	[Key in keyof Actions]: Actions[Key] | NoOp
+  [Key in keyof Actions]: Actions[Key] | NoOp;
 } & {
-	subscribe: Subscribe<State>
-}
+  subscribe: Subscribe<State>;
+};
 
-type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
+type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void
+  ? I
+  : never;
 
-declare const svelteFsm: <Sts extends Readonly<BaseStates>, S extends ExtractStates<Sts>>(state: S, states: Sts) => StateMachine<ExtractStates<Sts>, UnionToIntersection<ExtractActions<Sts>>>
+declare const svelteFsm: <Sts extends Readonly<BaseStates>, S extends ExtractStates<Sts>>(
+  state: S,
+  states: Sts
+) => StateMachine<ExtractStates<Sts>, UnionToIntersection<ExtractActions<Sts>>>;
 
-export default svelteFsm
+export default svelteFsm;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,12 @@
 
 declare type State = string | symbol
 
-declare type States = Record<State, unknown>
+declare type States = Record<State, StateDescription>
+
+declare type StateDescription = {
+	[key: string]: State | (() => State)
+}
 
 declare type ExtractStates<S extends States> = keyof S
 
-export default function svelteFsm<S extends States>(state: ExtractStates<S>, states: S): any;
+export default function svelteFsm<S extends States>(state: ExtractStates<S>, states: S): any

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,14 @@
 
 declare type State = string | symbol
 
-declare type States = Record<State, StateDescription>
+declare type States = Record<State, Actions>
 
-declare type StateDescription = {
-	[key: string]: State | ((...args: any[]) => State | void)
+declare type LifecycleAction = (argument: { from: State, to: State, event: string, args: unknown }) => void
+
+declare type Actions = {
+	_enter?: LifecycleAction
+	_exit?: LifecycleAction
+	[key: string]: State | ((...args: any[]) => State) | ((...args: any[]) => void)
 }
 
 declare type ExtractStates<S extends States> = keyof S

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,6 +45,6 @@ type StateMachine<S extends State, A> = {
 
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
 
-declare const svelteFsm: <Sts extends States, S extends ExtractStates<Sts>>(state: S, states: Sts) => StateMachine<ExtractStates<Sts>, UnionToIntersection<ExtractActions<Sts>>>
+declare const svelteFsm: <Sts extends Readonly<States>, S extends ExtractStates<Sts>>(state: S, states: Sts) => StateMachine<ExtractStates<Sts>, UnionToIntersection<ExtractActions<Sts>>>
 
 export default svelteFsm

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,18 +9,20 @@ declare type Args = any[]
 
 declare type LifecycleAction = (arg: { from: State, to: State, event: Action, args: Args }) => void
 
+declare type ActionFunction = State | ((...args: Args) => State) | ((...args: Args) => void)
+
 declare type Actions = {
 	_enter?: LifecycleAction
 	_exit?: LifecycleAction
-	[key: string]: State | ((...args: Args) => State) | ((...args: Args) => void)
+	[key: string]: ActionFunction
 }
 
 declare type ExtractStates<Sts extends States> = keyof Sts
 
 type ExtractObjectValues<A> = A[keyof A]
 
-type GetActionMapping<A extends Record<any, any>> = ExtractObjectValues<{
-	[a in keyof A]: keyof A[a]
+type GetActionMapping<A extends Record<State, Actions>> = ExtractObjectValues<{
+	[key in keyof A]: A[key] extends State ? () => A[key] : A[key] // TODO: make if-condition work
 }>
 
 declare type ExtractActions<Sts extends States> = Exclude<GetActionMapping<Sts>, '_enter' | '_exit' | number | Symbol>
@@ -29,12 +31,14 @@ declare type Unsubscribe = () => void
 
 declare type Subscribe<S> = (callback: (state: S) => void) => Unsubscribe
 
-type StateMachine<S extends State, A extends string> = {
-	[key in A]?: (...args: Args) => S // TODO: check if actions are really optional
+type StateMachine<S extends State, A> = {
+	[key in keyof A]?: A[key] // TODO: check if actions are really optional
 } & {
 	subscribe: Subscribe<S>
 }
 
-declare const svelteFsm: <Sts extends States, S extends ExtractStates<Sts>>(state: S, states: Sts) => StateMachine<ExtractStates<Sts>, ExtractActions<Sts>>
+type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
+
+declare const svelteFsm: <Sts extends States, S extends ExtractStates<Sts>>(state: S, states: Sts) => StateMachine<ExtractStates<Sts>, UnionToIntersection<ExtractActions<Sts>>>
 
 export default svelteFsm

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,17 +1,17 @@
 
-declare type State = string | symbol
+type State = string | symbol
 
-declare type Action = string
+type Action = string
 
-declare type States<S extends State = State> = Record<S, Actions>
+type States<S extends State = State> = Record<S, Actions>
 
-declare type Args = any[]
+type Args = any[]
 
-declare type LifecycleAction = (arg: { from: State, to: State, event: Action, args: Args }) => void
+type LifecycleAction = (arg: { from: State, to: State, event: Action, args: Args }) => void
 
-declare type ActionFunction = State | ((...args: Args) => State) | ((...args: Args) => void)
+type ActionFunction = State | ((...args: Args) => State) | ((...args: Args) => void)
 
-declare type Actions = {
+type Actions = {
 	_enter?: LifecycleAction
 	_exit?: LifecycleAction
 	[key: Action]: ActionFunction
@@ -19,7 +19,7 @@ declare type Actions = {
 
 type DetectFallBackState<X extends string | symbol> = X extends '*' ? string : X
 
-declare type ExtractStates<Sts extends States> = DetectFallBackState<Exclude<keyof Sts, number>>
+type ExtractStates<Sts extends States> = DetectFallBackState<Exclude<keyof Sts, number>>
 
 type ExtractObjectValues<A> = A[keyof A]
 
@@ -31,11 +31,11 @@ type GetActionMapping<A extends Record<State, Actions>> = ExtractObjectValues<{
 	[Key in keyof A]: GetActionFunctionMapping<A[Key]>
 }>
 
-declare type ExtractActions<Sts extends States> = GetActionMapping<Sts>
+type ExtractActions<Sts extends States> = GetActionMapping<Sts>
 
-declare type Unsubscribe = () => void
+type Unsubscribe = () => void
 
-declare type Subscribe<S> = (callback: (state: S) => void) => Unsubscribe
+type Subscribe<S> = (callback: (state: S) => void) => Unsubscribe
 
 type StateMachine<S extends State, A> = {
 	[key in keyof A]: A[key]

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ type BaseStates<State extends BaseState = BaseState> = Record<State, BaseActions
 
 type Args = any[]
 
-type LifecycleAction = (arg: { from: BaseState, to: BaseState, event: BaseAction, args: Args }) => void
+type LifecycleAction = (arg: { from: BaseState | null, to: BaseState, event: BaseAction | null, args: Args }) => void
 
 type NoOp = () => void
 
@@ -40,7 +40,7 @@ type Unsubscribe = () => void
 type Subscribe<S extends BaseState> = (callback: (state: S) => void) => Unsubscribe
 
 type StateMachine<State extends BaseState, Actions> = {
-	[key in keyof Actions]: Actions[key] // TODO: include NoOp if action is not present on all states
+	[Key in keyof Actions]: Actions[Key] // TODO: include NoOp if action is not present on all states
 } & {
 	subscribe: Subscribe<State>
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,9 @@ declare type Actions = {
 	[key: Action]: ActionFunction
 }
 
-declare type ExtractStates<Sts extends States> = Exclude<keyof Sts, number>
+type DetectFallBackState<X extends string | symbol> = X extends '*' ? string : X
+
+declare type ExtractStates<Sts extends States> = DetectFallBackState<Exclude<keyof Sts, number>>
 
 type ExtractObjectValues<A> = A[keyof A]
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,9 @@ type Args = any[]
 
 type LifecycleAction = (arg: { from: BaseState, to: BaseState, event: BaseAction, args: Args }) => void
 
-type ActionFunction = BaseState | ((...args: Args) => BaseState) | ((...args: Args) => void)
+type NoOp = () => void
+
+type ActionFunction = BaseState | ((...args: Args) => BaseState) | ((...args: Args) => void) | NoOp
 
 type BaseActions = {
 	_enter?: LifecycleAction
@@ -38,7 +40,7 @@ type Unsubscribe = () => void
 type Subscribe<S extends BaseState> = (callback: (state: S) => void) => Unsubscribe
 
 type StateMachine<State extends BaseState, Actions> = {
-	[key in keyof Actions]: Actions[key]
+	[key in keyof Actions]: Actions[key] // TODO: include NoOp if action is not present on all states
 } & {
 	subscribe: Subscribe<State>
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ type Unsubscribe = () => void
 type Subscribe<S extends BaseState> = (callback: (state: S) => void) => Unsubscribe
 
 type StateMachine<State extends BaseState, Actions> = {
-	[Key in keyof Actions]: Actions[Key] // TODO: include NoOp if action is not present on all states
+	[Key in keyof Actions]: Actions[Key] | NoOp
 } & {
 	subscribe: Subscribe<State>
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,7 @@ declare type Unsubscribe = () => void
 declare type Subscribe<S> = (callback: (state: S) => void) => Unsubscribe
 
 type StateMachine<S extends State, A> = {
-	[key in keyof A]?: A[key] // TODO: check if actions are really optional
+	[key in keyof A]: A[key]
 } & {
 	subscribe: Subscribe<S>
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,18 +14,22 @@ declare type ActionFunction = State | ((...args: Args) => State) | ((...args: Ar
 declare type Actions = {
 	_enter?: LifecycleAction
 	_exit?: LifecycleAction
-	[key: string]: ActionFunction
+	[key: Action]: ActionFunction
 }
 
 declare type ExtractStates<Sts extends States> = keyof Sts
 
 type ExtractObjectValues<A> = A[keyof A]
 
+type GetActionFunctionMapping<A extends Record<Action, ActionFunction>> = {
+	[Key in Exclude<keyof A, '_enter' | '_exit'>]: A[Key] extends string ? () => A[Key] : A[Key]
+}
+
 type GetActionMapping<A extends Record<State, Actions>> = ExtractObjectValues<{
-	[key in keyof A]: A[key] extends State ? () => A[key] : A[key] // TODO: make if-condition work
+	[Key in keyof A]: GetActionFunctionMapping<A[Key]>
 }>
 
-declare type ExtractActions<Sts extends States> = Exclude<GetActionMapping<Sts>, '_enter' | '_exit' | number | Symbol>
+declare type ExtractActions<Sts extends States> = GetActionMapping<Sts>
 
 declare type Unsubscribe = () => void
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,8 @@
-export default function svelteFsm(state: string | symbol, states: object): function;
+
+declare type State = string | symbol
+
+declare type States = Record<State, unknown>
+
+declare type ExtractStates<S extends States> = keyof S
+
+export default function svelteFsm<S extends States>(state: ExtractStates<S>, states: S): any;

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ declare type State = string | symbol
 declare type States = Record<State, StateDescription>
 
 declare type StateDescription = {
-	[key: string]: State | (() => State)
+	[key: string]: State | ((...args: any[]) => State | void)
 }
 
 declare type ExtractStates<S extends States> = keyof S

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "devDependencies": {
         "chai": "^4.3.4",
         "mocha": "^9.1.3",
-        "sinon": "^12.0.1"
+        "sinon": "^12.0.1",
+        "typescript": "^4.5.2"
       },
       "engines": {
         "node": ">=14.0.0",
@@ -1011,6 +1012,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -1852,6 +1866,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   },
   "types": "index.d.ts",
   "scripts": {
-    "test": "mocha"
+    "test": "npm run test:units && npm run test:types",
+    "test:units": "mocha",
+    "test:types": "tsc --noEmit test/*.ts"
   },
   "engines": {
     "node": ">=14.0.0",
@@ -37,6 +39,7 @@
   "devDependencies": {
     "chai": "^4.3.4",
     "mocha": "^9.1.3",
-    "sinon": "^12.0.1"
+    "sinon": "^12.0.1",
+    "typescript": "^4.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "test": "npm run test:units && npm run test:types",
     "test:units": "mocha",
-    "test:types": "tsc --noEmit test/*.ts"
+    "test:types": "tsc --noEmit --target es6 test/*.ts"
   },
   "engines": {
     "node": ">=14.0.0",

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,6 +1,6 @@
 /*
  * Verify type declarations found in index.d.ts by running:
- * $ npx tsc --noEmit test/types.ts
+ * $ npx tsc --noEmit --target es6 test/types.ts
  */
 import fsm from '../index.js';
 
@@ -54,8 +54,8 @@ valid1.noSuchAction();
 valid1.toggle(1);
 valid1.toggle();
 
-const toggleResultValid: string | void = valid1.toggle();
-// @ts-expect-error toggle returns string or void
+const toggleResultValid: string | symbol = valid1.toggle();
+// @ts-expect-error toggle returns string or symbol
 const toggleResultInvalid: number = valid1.toggle();
 
 // A state machine with fallback state (any initial state permitted)
@@ -95,3 +95,11 @@ const overloadedResult1Valid: string | void = valid3.overloaded(1);
 // @ts-expect-error overloaded with two arguments returns only void
 const overloadedResult2Invalid: string = valid3.overloaded('string', 1);
 const overloadedResult2Valid: string | void = valid3.overloaded('string', 1);
+
+// A state machine that uses symbols as a state keys
+const valid4 = fsm(Symbol.for('foo'), {
+  [Symbol.for('foo')]: {
+    bar: Symbol.for('bar')
+  }
+});
+const symbolResultValid: string | symbol = valid4.bar();

--- a/test/types.ts
+++ b/test/types.ts
@@ -43,7 +43,7 @@ const valid1 = fsm('off', {
 // @ts-expect-error subscribe expects callback
 valid1.subscribe();
 const unsub = valid1.subscribe(() => {});
-// @ts-expect-error unsubscribe expects no argumernts
+// @ts-expect-error unsubscribe expects no arguments
 unsub('foo');
 unsub();
 
@@ -53,6 +53,10 @@ valid1.noSuchAction();
 // @ts-expect-error toggle expects no arguments (1 provided)
 valid1.toggle(1);
 valid1.toggle();
+
+const toggleResultValid: string | void = valid1.toggle();
+// @ts-expect-error toggle returns string or void
+const toggleResultInvalid: number = valid1.toggle();
 
 // A state machine with fallback state (any initial state permitted)
 const valid2 = fsm('initial', {
@@ -65,15 +69,29 @@ valid2.foo();
 // A state machine with overloaded action signatures
 const valid3 = fsm('initial', {
   '*': {
-    overloaded(one) {}
+    overloaded(one: number) {
+      return 'foo'
+    }
   },
   'foo': {
-    overloaded(one, two) {}
+    overloaded(one: string, two: number) { }
   }
 });
 // @ts-expect-error overloaded expects 1 or 2 args (0 provided)
 valid3.overloaded();
+// @ts-expect-error overloaded expects first argument as number
+valid3.overloaded('string');
 valid3.overloaded(1);
+// @ts-expect-error overloaded expects first argument as string
 valid3.overloaded(1, 2);
+valid3.overloaded('string', 2);
 // @ts-expect-error overloaded expects 1 or 2 args (3 provided)
 valid3.overloaded(1, 2, 3);
+
+// @ts-expect-error overloaded with single argument returns string | void
+const overloadedResult1Invalid: void = valid3.overloaded(1)
+const overloadedResult1Valid: string | void = valid3.overloaded(1)
+
+// @ts-expect-error overloaded with two arguments returns only void
+const overloadedResult2Invalid: string = valid3.overloaded('string', 1)
+const overloadedResult2Valid: string | void = valid3.overloaded('string', 1)

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,0 +1,79 @@
+/*
+ * Verify type declarations found in index.d.ts by running:
+ * $ npx tsc --noEmit test/types.ts
+ */
+import fsm from '../index.js';
+
+// @ts-expect-error fsm expects 2 arguments (0 provided)
+const invalid1 = fsm();
+// @ts-expect-error fsm expects 2 arguments (1 provided)
+const invalid2 = fsm('foo');
+// @ts-expect-error fsm expects string or symbol for initial state (null provided)
+const invalid3 = fsm(null, {});
+// @ts-expect-error fsm expects string or symbol for initial state (number provided)
+const invalid4 = fsm(1, {});
+// @ts-expect-error fsm expects object for states (string provided)
+const invalid5 = fsm('foo', 'bar');
+// @ts-expect-error fsm expects initial state to match a defined state or fallback
+const invalid6 = fsm('foo', {});
+
+const invalid7 = fsm('foo', {
+  foo: {
+    // @ts-expect-error state expects action to be string or function (object provided)
+    bar: {},
+    // @ts-expect-error state expects action to be string or function (number provided)
+    baz: 1,
+    // @ts-expect-error state expects lifecycle action to be function (string provided)
+    _enter: 'bar'
+  }
+});
+
+// A simple, valid state machine
+const valid1 = fsm('off', {
+  off: {
+    toggle: 'on'
+  },
+  on: {
+    toggle() {
+      return 'off';
+    }
+  }
+});
+
+// @ts-expect-error subscribe expects callback
+valid1.subscribe();
+const unsub = valid1.subscribe(() => {});
+// @ts-expect-error unsubscribe expects no argumernts
+unsub('foo');
+unsub();
+
+// @ts-expect-error state machine expects valid event invocation
+valid1.noSuchAction();
+
+// @ts-expect-error toggle expects no arguments (1 provided)
+valid1.toggle(1);
+valid1.toggle();
+
+// A state machine with fallback state (any initial state permitted)
+const valid2 = fsm('initial', {
+  '*': {
+    foo: () => {}
+  },
+});
+valid2.foo();
+
+// A state machine with overloaded action signatures
+const valid3 = fsm('initial', {
+  '*': {
+    overloaded(one) {}
+  },
+  'foo': {
+    overloaded(one, two) {}
+  }
+});
+// @ts-expect-error overloaded expects 1 or 2 args (0 provided)
+valid3.overloaded();
+valid3.overloaded(1);
+valid3.overloaded(1, 2);
+// @ts-expect-error overloaded expects 1 or 2 args (3 provided)
+valid3.overloaded(1, 2, 3);

--- a/test/types.ts
+++ b/test/types.ts
@@ -62,7 +62,7 @@ const toggleResultInvalid: number = valid1.toggle();
 const valid2 = fsm('initial', {
   '*': {
     foo: () => {}
-  },
+  }
 });
 valid2.foo();
 
@@ -70,11 +70,11 @@ valid2.foo();
 const valid3 = fsm('initial', {
   '*': {
     overloaded(one: number) {
-      return 'foo'
+      return 'foo';
     }
   },
-  'foo': {
-    overloaded(one: string, two: number) { }
+  foo: {
+    overloaded(one: string, two: number) {}
   }
 });
 // @ts-expect-error overloaded expects 1 or 2 args (0 provided)
@@ -89,9 +89,9 @@ valid3.overloaded('string', 2);
 valid3.overloaded(1, 2, 3);
 
 // @ts-expect-error overloaded with single argument returns string | void
-const overloadedResult1Invalid: void = valid3.overloaded(1)
-const overloadedResult1Valid: string | void = valid3.overloaded(1)
+const overloadedResult1Invalid: void = valid3.overloaded(1);
+const overloadedResult1Valid: string | void = valid3.overloaded(1);
 
 // @ts-expect-error overloaded with two arguments returns only void
-const overloadedResult2Invalid: string = valid3.overloaded('string', 1)
-const overloadedResult2Valid: string | void = valid3.overloaded('string', 1)
+const overloadedResult2Invalid: string = valid3.overloaded('string', 1);
+const overloadedResult2Valid: string | void = valid3.overloaded('string', 1);

--- a/test/units.js
+++ b/test/units.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import sinon from 'sinon';
-import fsm from './index.js';
+import fsm from '../index.js';
 
 sinon.assert.expose(assert, { prefix: '' });
 

--- a/test/units.js
+++ b/test/units.js
@@ -70,13 +70,13 @@ describe('a finite state machine', () => {
     });
 
     it('should call subscribe action handler when invoked with multiple args', () => {
-      const fn = sinon.fake()
+      const fn = sinon.fake();
       machine.subscribe(fn, null);
       assert.calledWithExactly(states.off.subscribe, fn, null);
     });
   });
 
-  describe('event invocations', function() {
+  describe('event invocations', () => {
     let callback;
     let unsubscribe;
 
@@ -145,8 +145,8 @@ describe('a finite state machine', () => {
         from: null,
         to: 'off',
         event: null,
-        args: [] }
-      );
+        args: []
+      });
     });
 
     it('should call lifecycle actions with transition metadata', () => {
@@ -236,7 +236,7 @@ describe('a finite state machine', () => {
       const kick = machine.kick.debounce(100, 1);
       const cancelation = machine.kick.debounce(null);
       clock.tick(100);
-      const state = await Promise.any([ kick, cancelation ]);
+      const state = await Promise.any([kick, cancelation]);
       assert.notCalled(states.off.kick);
       assert.equal('off', state);
     });


### PR DESCRIPTION
I have added a few TypeDefinitions.
This PR is still WIP. 

Implemented typesafety/autocompletion features:
- typesafe initial state
![image](https://user-images.githubusercontent.com/21335119/143106768-605eba1c-695e-4764-a048-df423d2314ed.png)

- typed subscribe function
![image](https://user-images.githubusercontent.com/21335119/143108936-1517e821-ca61-4fce-b5f0-6d16d0bf31fa.png)

- typed action calls
![image](https://user-images.githubusercontent.com/21335119/143764779-cd85b82c-68ba-4712-aa03-a3683c34847a.png)
![image](https://user-images.githubusercontent.com/21335119/143764790-7d6ec6ce-f540-48d9-aaa0-c18a8bcd8835.png)
![image](https://user-images.githubusercontent.com/21335119/143764796-3ca7be6e-a530-4e02-bd42-3cd7b8be704f.png)

- halfly-typed arguments for lifecycle methods
   (the arguments are typed as string, but aren't restricted to the exact state values, like `'initial' | 'final'`)
![image](https://user-images.githubusercontent.com/21335119/143601586-c1b00d1d-ff87-413c-b279-8db3f29e6d11.png)

- only allow actions that the state-machine can handle
![image](https://user-images.githubusercontent.com/21335119/143601774-737a8437-4ad3-47a6-b6ea-6a218c33431a.png)


Please let me know if I made wrong assumptions about the functionality of the state machine code.