### PR TITLE
Don't make subscribe actions call invoke

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,9 @@ export default function (state, states = {}) {
   let proxy;
 
   function subscribe(callback) {
+    if (typeof callback !== 'function') {
+      throw new TypeError("Invalid callback");
+    }
     subscribers.add(callback);
     callback(state);
     return () => subscribers.delete(callback);
@@ -64,17 +67,7 @@ export default function (state, states = {}) {
    * - subscribe() also behaves as an event invoker when called with any args other than a
    *   single callback (or when debounced)
    */
-  function subscribeOrInvoke(...args) {
-    if (args.length === 1 && args[0] instanceof Function) {
-      return subscribe(args[0]);
-    } else {
-      invoke('subscribe', ...args);
-    }
-  }
-
-  subscribeOrInvoke.debounce = debounce.bind(null, 'subscribe');
-
-  proxy = new Proxy({ subscribe: subscribeOrInvoke }, {
+  proxy = new Proxy({ subscribe }, {
     get(target, property) {
       if (!Reflect.has(target, property)) {
         target[property] = invoke.bind(null, property);

--- a/test/units.js
+++ b/test/units.js
@@ -60,20 +60,22 @@ describe('a finite state machine', () => {
       unsubscribe();
     });
 
-    it('should call subscribe action handler when invoked with no args', () => {
-      machine.subscribe();
-      assert.calledOnce(states.off.subscribe);
+    it('should fail subscribe action handler when invoked with no args', () => {
+      assert.throws(() => {
+        machine.subscribe();
+      }, TypeError);
     });
 
     it('should call subscribe action handler when invoked with single non-function arg', () => {
-      machine.subscribe('not a function');
-      assert.calledWithExactly(states.off.subscribe, 'not a function');
+      assert.throws(() => {
+        machine.subscribe('not a function');
+      }, TypeError);
     });
 
-    it('should call subscribe action handler when invoked with multiple args', () => {
+    it('should not call subscribe action handler when invoked with multiple args', () => {
       const fn = sinon.fake();
       machine.subscribe(fn, null);
-      assert.calledWithExactly(states.off.subscribe, fn, null);
+      assert.neverCalledWith(states.off.subscribe, fn, null);
     });
   });
 


### PR DESCRIPTION
This is a pull request related to #8, and fixes the issues of derived stores building on an FSM. I am very happy to revise this, but it's a first pass at the resolution. 

What this code does is: revise so that _all_ `fsm.subscribe(...)` calls are now listener setups, rather than actions. Previously, there was a heuristic based on the number of arguments, which breaks, because Svelte sometimes issues subscribe calls with more than the expected number. Specifically, with derived stores. It includes a very light touch amendment to the tests.

There _will_ be issues if anyone has used `subscribe()` in this 'overloaded' way. That would, obviously, not be a good thing to do, and I suspect it is very much a corner case. If that solution isn't enough, we'll need to find another approach. But right now, `svelte-fsm` isn't usable with derived stores.